### PR TITLE
Add fast_underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ Best suited for map-reduce or e.g. parallel downloads/uploads.
 
 * [bootsnap](https://github.com/Shopify/bootsnap) - Boot large Ruby/Rails apps faster.
 * [fast_blank](https://github.com/SamSaffron/fast_blank) - Provides a C-optimized method for determining if a string is blank.
+* [fast_underscore](https://github.com/kddeisz/fast_underscore) - Provides a C-optimized method for transforming a string from any capitalization into underscore-separated
 * [yajl-ruby](https://github.com/brianmario/yajl-ruby) - A streaming JSON parsing and encoding library for Ruby (C bindings to yajl).
 
 ## ORM/ODM


### PR DESCRIPTION
## Project

fast_underscore

* [rubygems](https://rubygems.org/gems/fast_underscore)
* [github](https://github.com/kddeisz/fast_underscore)

## What is this Ruby project?

fast_blank-like C extension but for `String#underscore`.

## What are the main difference between this Ruby project and similar ones?

I don't think there are any others that do this.